### PR TITLE
fix(qwen3.5): reuse persistent output buffers in fused QK kernel

### DIFF
--- a/python/sglang/srt/layers/fused_qk_rmsnorm_rope_gate.py
+++ b/python/sglang/srt/layers/fused_qk_rmsnorm_rope_gate.py
@@ -18,6 +18,20 @@ import torch
 import triton
 import triton.language as tl
 
+# Persistent (graph-safe) output buffers. Per-call torch.empty here gets captured into
+# the EAGLE draft cuda graphs; dynamic allocs alias across the ~35 captured graphs
+# (shared mempool) -> graph-replay memory corruption -> IMA on sm_100 (GB200).
+# Reusing a buffer per (shape,dtype,device) keeps capture allocation-free.
+_QK_OUT_CACHE = {}
+def _qk_buf(shape, dtype, device):
+    k = (tuple(shape), dtype, device)
+    b = _QK_OUT_CACHE.get(k)
+    if b is None:
+        b = torch.empty(shape, dtype=dtype, device=device)
+        _QK_OUT_CACHE[k] = b
+    return b
+
+
 # ---------------------------------------------------------------------------
 # v2 kernel — bf16 round-trip, full HEAD_BLOCK load, reload rotary for RoPE
 # ---------------------------------------------------------------------------
@@ -325,13 +339,11 @@ def fused_qk_gemma_rmsnorm_rope_gate_v2(
     q_size = num_q_heads * head_dim
     kv_size = num_kv_heads * head_dim
 
-    q_out = torch.empty(T, q_size, dtype=q_gate.dtype, device=q_gate.device)
-    k_out = torch.empty(T, kv_size, dtype=k.dtype, device=k.device)
+    q_out = _qk_buf((T, q_size), q_gate.dtype, q_gate.device)
+    k_out = _qk_buf((T, kv_size), k.dtype, k.device)
 
     if has_gate:
-        gate_out = torch.empty(
-            T, num_q_heads, head_dim, dtype=q_gate.dtype, device=q_gate.device
-        )
+        gate_out = _qk_buf((T, num_q_heads, head_dim), q_gate.dtype, q_gate.device)
     else:
         gate_out = q_out  # dummy
 
@@ -401,13 +413,11 @@ def fused_qk_gemma_rmsnorm_rope_gate(
     HAS_NOPE = NOPE_DIM > 0
     NOPE_BLOCK = triton.next_power_of_2(NOPE_DIM) if NOPE_DIM > 0 else 1
 
-    q_out = torch.empty(T, q_size, dtype=q_gate.dtype, device=q_gate.device)
-    k_out = torch.empty(T, kv_size, dtype=k.dtype, device=k.device)
+    q_out = _qk_buf((T, q_size), q_gate.dtype, q_gate.device)
+    k_out = _qk_buf((T, kv_size), k.dtype, k.device)
 
     if has_gate:
-        gate_out = torch.empty(
-            T, num_q_heads, head_dim, dtype=q_gate.dtype, device=q_gate.device
-        )
+        gate_out = _qk_buf((T, num_q_heads, head_dim), q_gate.dtype, q_gate.device)
     else:
         gate_out = q_out
 


### PR DESCRIPTION
## Summary

- Reuse persistent output buffers in fused_qk_gemma_rmsnorm_rope_gate wrappers instead of allocating q_out/k_out/gate_out with torch.empty on every call.
- Key the reusable buffers by shape, dtype, and device so CUDA graph capture is allocation-free for this path.
- Keep the kernel behavior unchanged while avoiding captured allocation aliasing across EAGLE draft graphs.

## Root cause

The fused QK wrappers allocated temporary outputs on every call. Those allocations were captured into EAGLE draft CUDA graphs; with many draft graphs sharing one mempool, replay can alias the captured allocations across graphs and corrupt memory, causing illegal memory access on GB200 sm_100. The issue does not reproduce on GB300 sm_103 with the observed allocation layout and is masked by SGLANG_SIMULATE_ACC_LEN because that bypasses the real draft path.

## Validation

- Git bisect lands on the fused-QK-kernel commit.
- Isolated the kernel as numerically correct and in-bounds; host-side syncs do not fix the crash, pointing to graph replay.
- Confirmed replacing per-call allocations with persistent buffers fixes the crash.
- Validated on GB200 with EAGLE + NVFP4 real accept, both plain and full dual-stream/overlap commands.
- No crash; accept length and TPOT match the native path, accept approximately 3.6 and TPOT approximately 1.95 ms.
- No measurable performance impact.